### PR TITLE
Add workflow

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -1,0 +1,23 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi_release:
+    name: Builds Using Poetry and Publishes to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+              python-version: '3.11.2'
+      - name: Install Poetry
+        run: curl -sSL https://install.python-poetry.org | python3 -
+      - name: Add Poetry to path
+        run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+      - run: poetry install
+      - run: poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
+      - name: Publish package
+        run: poetry publish --build

--- a/README.md
+++ b/README.md
@@ -6,4 +6,3 @@ This submodule contains bindings to the Taskchampion
 
 - There is no good way to describe functions that accept interface (e.g. `Replica::new` accepts any of the storage implementations, but Python bindings lack such mechanisms), currently, `Replica::new` just constructs the SqliteStorage from the params passed into the constructor.
 - It is possible to convert `WorkingSet` into a python iterator (you can iterate over it via `for item in <blah>:` or `next(<blah>)`), but that needs a way to store the current state.
-- Possible integration with Github Workflows for deployment.


### PR DESCRIPTION
I saw that you were looking at using a Github workflow to publish the package. This is based on a workflow that I use for one of my Python packages that's controlled by Poetry. It would publish the package whenever you create a Github release. 

This workflow would require you to create a secret for the repo called PYPI_TOKEN that would use a token (rather than username/password) to publish the package to your PyPi account. 