### PR TITLE
Update package metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,8 +1467,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "taskchampion_python"
-version = "0.1.0"
+name = "taskchampion-py"
+version = "0.7.0-pre1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "taskchampion_python"
-version = "0.1.0"
+name = "taskchampion-py"
+version = "0.7.0-pre1"
 edition = "2021"
+# This should match the MSRV of the `taskchampion` crate.
+rust-version = "1.78.0"
 
 [package.metadata.maturin]
 name = "taskchampion"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 name = "taskchampion"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Python Taskchampion Bindings
 
-This submodule contains bindings to the Taskchampion
+This package contains Python bindings for [TaskChampion](https://github.com/GothenburgBitFactory/taskchampion).
+It follows the TaskChampion API closely, with minimal adaptation for Python.
+
+## Versioning
+
+The `taskchampion-py` package version matches the Rust crate's version.
+When an additional package release is required for the same Rust crate, a fourth version component is used; for example `1.2.0.1` for the second release of `taskchampion-py` containing TaskChampion version `1.2.0`.
 
 ## Development
 


### PR DESCRIPTION
 - Name the package `taskchampion-py` consistently.
 - Use the TaskChampion version number.
 - Track the MSRV of TaskChampion.

For the moment, the version is 0.7.0-pre1 so that we can test releasing later.