### PR TITLE
Replica is not Send

### DIFF
--- a/src/replica.rs
+++ b/src/replica.rs
@@ -6,12 +6,14 @@ use crate::{DependencyMap, Operations, Task, WorkingSet};
 use pyo3::prelude::*;
 use taskchampion::{Replica as TCReplica, ServerConfig, StorageConfig, Uuid};
 
-#[pyclass]
+#[pyclass(unsendable)]
 /// A replica represents an instance of a user's task data, providing an easy interface
 /// for querying and modifying that data.
+///
+/// A replica can only be used in the thread in which it was created. Use from any other
+/// thread will panic.
 pub struct Replica(TCReplica);
 
-unsafe impl Send for Replica {}
 #[pymethods]
 impl Replica {
     #[staticmethod]


### PR DESCRIPTION
The TC type `Replica` is legitimately not `Send`, because it embeds a `Storge` implementation and that implementation may not be `Send`. In fact, the SQLite implementation is not -- SQLite is single-threaded.

I think this is a reasonable restriction for the library for the moment. If there is at some point a need to use a Replica from multiple threads, then we can consider ways to lift this restriction safely.