### PR TITLE
Run pytest from source and on built wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,18 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+
+  pytest-linux:
+    runs-on: ubuntu-latest
+    name: "Python Tests (on built wheel)"
+    needs: linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - run: pip install poetry
+      - run: poetry install
+      - run: poetry run pip install wheels-linux-x86_64/*
+      - run: poetry run pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: "Python Tests"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.78.0" # MSRV
+          override: true
+          components: clippy
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - run: pip install poetry
+      - run: poetry install
+      - run: poetry run maturin develop
+      - run: poetry run pytest


### PR DESCRIPTION
I thought we were running `pytest` in CI already, but no!

This runs it both against the source, with `maturin develop` -- which is pretty fast -- and against a built wheel, which is slower but might catch things not being built correctly.