### PR TITLE
Update to TaskChampion-2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "taskchampion"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba26a986269f2b24f34d64f777abca9abb3f2923fd83111ce831100f292459f"
+checksum = "830bb062bb2d89bdee0063d7c02d1e24ee0a1702c683f394eb0520fb88dc4a5c"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion-py"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion-py"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 # This should match the MSRV of the `taskchampion` crate.
 rust-version = "1.81.0"
@@ -16,4 +16,4 @@ doc = false
 [dependencies]
 pyo3 = { version = "0.22.6", features = ["chrono"] }
 chrono = "*"
-taskchampion = { version = "=2.0.1" }
+taskchampion = { version = "=2.0.2" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskchampion-py"
-version = "2.0.1"
+version = "2.0.2"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
This includes a fix for https://github.com/GothenburgBitFactory/taskchampion/issues/527. For taskchampion-py it's a simple version bump.