### PR TITLE
Generate basic API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+# Derived from
+# https://raw.githubusercontent.com/mitmproxy/pdoc/refs/heads/main/.github/workflows/docs.yml
+
+name: API Docs
+
+on:
+  push:
+    branches:
+      - main
+
+# security: restrict permissions for CI jobs.
+permissions:
+  contents: read
+
+jobs:
+  # Build the documentation and upload the static HTML files as an artifact.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - run: pip install poetry
+      - run: poetry install
+      - run: poetry run maturin develop
+      - run: poetry run pdoc -o docs/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+  # Deploy the artifact to GitHub pages.
+  # This is a separate job so that only actions/deploy-pages has the necessary permissions.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/dependency_map.rs
+++ b/src/dependency_map.rs
@@ -2,8 +2,6 @@ use pyo3::prelude::*;
 use std::sync::Arc;
 use taskchampion::{DependencyMap as TCDependencyMap, Uuid};
 
-// See `Replica::dependency_map` for the rationale for using a raw pointer here.
-
 #[pyclass]
 pub struct DependencyMap(Arc<TCDependencyMap>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,18 +18,30 @@ use task::{Annotation, Status, Tag, Task, TaskData};
 
 mod util;
 
+/// This module wraps TaskChampion in a Python API.
+///
+/// Most types and functions match those of [the TaskChampion Rust
+/// API](https://docs.rs/taskchampion/), with exceptions noted in the documentation here. See the
+/// TaskChampion documentation for details.
+///
+/// For the Rust `Option` type, the `None` variant is represented by Python's `None`, while
+/// the `Some` variant is represented by the contained value. For example, `Task.get_value`
+/// returns either `None` or a string containing the value.
+///
+/// Timestamps are represented as Python `datetime.datetime` values. UUIDs are represented
+/// as strings.
 #[pymodule]
 fn taskchampion(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Status>()?;
     m.add_class::<Replica>()?;
     m.add_class::<Task>()?;
     m.add_class::<TaskData>()?;
-    m.add_class::<Annotation>()?;
-    m.add_class::<WorkingSet>()?;
-    m.add_class::<Tag>()?;
-    m.add_class::<DependencyMap>()?;
     m.add_class::<Operation>()?;
     m.add_class::<Operations>()?;
+    m.add_class::<WorkingSet>()?;
+    m.add_class::<DependencyMap>()?;
+    m.add_class::<Annotation>()?;
+    m.add_class::<Status>()?;
+    m.add_class::<Tag>()?;
     m.add_class::<AccessMode>()?;
 
     Ok(())

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -6,14 +6,14 @@ use taskchampion::Operation as TCOperation;
 
 #[pyclass]
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Operation(pub(crate) TCOperation);
-
-#[pymethods]
-/// An Operation defines a single change to the task database, as stored locally in the replica.
+/// A TaskChampion Operation.
 ///
 /// This is an enum in Rust, represented here with four static constructors for the variants,
 /// four `is_..` methods for determining the type, and getters for each variant field. The
 /// getters raise `AttributeError` for variants that do not have the given property.
+pub struct Operation(pub(crate) TCOperation);
+
+#[pymethods]
 impl Operation {
     #[allow(non_snake_case)]
     #[staticmethod]
@@ -78,6 +78,7 @@ impl Operation {
     }
 
     #[getter(uuid)]
+    /// Present on the Create, Update, and Delete variants.
     pub fn get_uuid(&self) -> PyResult<String> {
         use TCOperation::*;
         match &self.0 {
@@ -91,6 +92,7 @@ impl Operation {
     }
 
     #[getter(old_task)]
+    /// Present on the Delete variant.
     pub fn get_old_task(&self) -> PyResult<HashMap<String, String>> {
         use TCOperation::*;
         match &self.0 {
@@ -102,6 +104,7 @@ impl Operation {
     }
 
     #[getter(property)]
+    /// Present on the Update variant.
     pub fn get_property(&self) -> PyResult<String> {
         use TCOperation::*;
         match &self.0 {
@@ -113,6 +116,7 @@ impl Operation {
     }
 
     #[getter(timestamp)]
+    /// Present on the Update variant.
     pub fn get_timestamp(&self) -> PyResult<DateTime<Utc>> {
         use TCOperation::*;
         match &self.0 {
@@ -124,6 +128,7 @@ impl Operation {
     }
 
     #[getter(old_value)]
+    /// Present on the Update variant.
     pub fn get_old_value(&self) -> PyResult<Option<String>> {
         use TCOperation::*;
         match &self.0 {
@@ -135,6 +140,7 @@ impl Operation {
     }
 
     #[getter(value)]
+    /// Present on the Update variant.
     pub fn get_value(&self) -> PyResult<Option<String>> {
         use TCOperation::*;
         match &self.0 {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -4,6 +4,10 @@ use taskchampion::Operations as TCOperations;
 
 #[pyclass(sequence)]
 #[derive(PartialEq, Eq, Clone, Debug)]
+/// A sequence of Operations.
+///
+/// This is a list-like type, and can be indexed, iterated over, and so on like any
+/// other list-like type.
 pub struct Operations(TCOperations);
 
 #[pymethods]

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -18,13 +18,10 @@ impl Replica {
     #[staticmethod]
     /// Create a Replica with on-disk storage.
     ///
-    /// Args:
-    ///     path (str): path to the directory with the database
-    ///     create_if_missing (bool): create the database if it does not exist
-    ///     access_mode (AccessMode): controls whether write access is allowed
-    /// Raises:
-    ///     RuntimeError: if database does not exist, and create_if_missing is false
-
+    /// This is equivalent to created a `StorgeConfig::OnDisk` with the given parameters and
+    /// passing that to `Replica::new`.
+    ///
+    /// Raises `RuntimeError` if the database does not exist, and `create_if_missing` is false
     #[pyo3(signature=(path, create_if_missing, access_mode=AccessMode::ReadWrite))]
     pub fn new_on_disk(
         path: String,
@@ -43,6 +40,7 @@ impl Replica {
     }
 
     #[staticmethod]
+    /// Create a Replica with in-memory storage.
     pub fn new_in_memory() -> PyResult<Self> {
         Ok(Replica(TCReplica::new(
             StorageConfig::InMemory
@@ -51,8 +49,6 @@ impl Replica {
         )))
     }
 
-    /// Create a new task
-    /// The task must not already exist.
     pub fn create_task(&mut self, uuid: String, ops: &mut Operations) -> PyResult<Task> {
         let task = self
             .0
@@ -62,7 +58,6 @@ impl Replica {
         Ok(task)
     }
 
-    /// Get a list of all tasks in the replica.
     pub fn all_tasks(&mut self) -> PyResult<HashMap<String, Task>> {
         Ok(self
             .0
@@ -82,7 +77,7 @@ impl Replica {
             .map(|(key, value)| (key.to_string(), TaskData::from(value)))
             .collect())
     }
-    /// Get a list of all uuids for tasks in the replica.
+
     pub fn all_task_uuids(&mut self) -> PyResult<Vec<String>> {
         Ok(self
             .0

--- a/src/task/status.rs
+++ b/src/task/status.rs
@@ -8,7 +8,8 @@ pub enum Status {
     Completed,
     Deleted,
     Recurring,
-    /// IMPORTANT: #[pyclass] only supports unit variants
+    // IMPORTANT: #[pyclass] only supports unit variants, so cannot keep the
+    // string form of this status.
     Unknown,
 }
 

--- a/src/task/tag.rs
+++ b/src/task/tag.rs
@@ -2,6 +2,10 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 use taskchampion::Tag as TCTag;
 
 #[pyclass(frozen, eq, hash)]
+/// A TaskChampion Tag.
+///
+/// The constructor for this type parses its argument using the `FromStr`
+/// trait, and supports both synthetic and user tags.
 #[derive(PartialEq, Eq, Hash)]
 pub struct Tag(TCTag);
 

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -22,151 +22,74 @@ impl Task {
         self.0.clone().into_task_data().into()
     }
 
-    /// Get a tasks UUID
-    ///
-    /// Returns:
-    ///     str: UUID of a task
     pub fn get_uuid(&self) -> String {
         self.0.get_uuid().to_string()
     }
 
-    /// Get a task's status
-    /// Returns:
-    ///     Status: Status subtype
     pub fn get_status(&self) -> Status {
         self.0.get_status().into()
     }
 
-    /// Get a task's description
     pub fn get_description(&self) -> String {
         self.0.get_description().to_string()
     }
 
-    /// Get the entry timestamp for a task
-    ///
-    /// Returns:
-    ///     str: RFC3339 timestamp
-    ///     None: No timestamp
     pub fn get_entry(&self) -> Option<DateTime<Utc>> {
         self.0.get_entry()
     }
 
-    /// Get the task's priority
-    ///
-    /// Returns:
-    ///     str: Task's priority
     pub fn get_priority(&self) -> String {
         self.0.get_priority().to_string()
     }
 
-    /// Get the wait timestamp of the task
-    ///
-    /// Returns:
-    ///     str: RFC3339 timestamp
-    ///     None: No timesamp
     pub fn get_wait(&self) -> Option<DateTime<Utc>> {
         self.0.get_wait()
     }
 
-    /// Check if the task is waiting
-    ///
-    /// Returns:
-    ///     bool: if the task is waiting
     pub fn is_waiting(&self) -> bool {
         self.0.is_waiting()
     }
 
-    /// Check if the task is active
-    ///
-    /// Returns:
-    ///     bool: if the task is active
     pub fn is_active(&self) -> bool {
         self.0.is_active()
     }
 
-    /// Check if the task is blocked
-    ///
-    /// Returns:
-    ///     bool: if the task is blocked
     pub fn is_blocked(&self) -> bool {
         self.0.is_blocked()
     }
 
-    /// Check if the task is blocking
-    ///
-    /// Returns:
-    ///     bool: if the task is blocking
     pub fn is_blocking(&self) -> bool {
         self.0.is_blocking()
     }
 
-    /// Check if the task has a tag
-    ///
-    /// Returns:
-    ///     bool: if the task has a given tag
     pub fn has_tag(&self, tag: &Tag) -> bool {
         self.0.has_tag(tag.as_ref())
     }
 
-    /// Get task tags
-    ///
-    /// Returns:
-    ///     list[str]: list of tags
     pub fn get_tags(&self) -> Vec<Tag> {
         self.0.get_tags().map(Tag::from).collect()
     }
 
-    /// Get task annotations
-    ///
-    /// Returns:
-    ///     list[Annotation]: list of task annotations
     pub fn get_annotations(&self) -> Vec<Annotation> {
         self.0.get_annotations().map(Annotation::from).collect()
     }
 
-    /// Get a task UDA
-    ///
-    /// Arguments:
-    ///     namespace (str): argument namespace
-    ///     key (str): argument key
-    ///
-    /// Returns:
-    ///     str: UDA value
-    ///     None: Not found
     pub fn get_uda(&self, namespace: &str, key: &str) -> Option<&str> {
         self.0.get_uda(namespace, key)
     }
 
-    /// get all the task's UDAs
-    ///
-    /// Returns:
-    ///    List of tuples ((namespace, key), value)
     pub fn get_udas(&self) -> Vec<((&str, &str), &str)> {
         self.0.get_udas().collect()
     }
 
-    /// Get the task modified time
-    ///
-    /// Returns:
-    ///     str: RFC3339 modified time
-    ///     None: Not applicable
     pub fn get_modified(&self) -> Option<DateTime<Utc>> {
         self.0.get_modified()
     }
 
-    /// Get the task's due date
-    ///
-    /// Returns:
-    ///     str: RFC3339 due date
-    ///     None: No such value
     pub fn get_due(&self) -> Option<DateTime<Utc>> {
         self.0.get_due()
     }
 
-    /// Get a list of tasks dependencies
-    ///
-    /// Returns:
-    ///     list[str]: List of UUIDs of the task depends on
     pub fn get_dependencies(&self) -> Vec<String> {
         self.0
             .get_dependencies()
@@ -174,11 +97,6 @@ impl Task {
             .collect()
     }
 
-    /// Get the task's property value
-    ///
-    /// Returns:
-    ///     str: property value
-    ///     None: no such value
     pub fn get_value(&self, property: String) -> Option<&str> {
         self.0.get_value(property)
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/14b6881f-55a0-4aa5-ac81-eddb45698088)

The results are pretty basic, all the more so because most of the items have no documentation, deferring instead to the Rust docs. But, I think it's sufficient. It should appear at something like https://gothenburgbitfactory.org/taskchampion-py once merged, and we can link to that from pypi, README, etc.