### PR TITLE
Correct API documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ r = Replica.new_on_disk("/some/path", true)
 ```
 
 See the [API
-documentation](https://github.com/GothenburgBitFactory/taskchampion-py/issues/6)
+documentation](https://gothenburgbitfactory.org/taskchampion-py/taskchampion.html)
 for more information.
 
 ## Development


### PR DESCRIPTION
Fix the link to link directly to the API documentation instead of having it to go a GH issue which then links to the API docs.